### PR TITLE
Adds client for testing websocket and stomp endpoints

### DIFF
--- a/app/ws-testing/WebSocketClient.css
+++ b/app/ws-testing/WebSocketClient.css
@@ -1,0 +1,77 @@
+.container {
+    padding: 16px;
+    border: 1px solid #ccc;
+    border-radius: 8px;
+    max-width: 600px;
+    margin: 32px auto;
+    background-color: white;
+    box-shadow: 0 4px 8px rgba(0, 0, 0, 0.1);
+}
+
+.title {
+    font-size: 1.5rem;
+    font-weight: bold;
+    margin-bottom: 16px;
+    text-align: center;
+    color:black
+}
+
+.input-group {
+    margin-bottom: 16px;
+}
+
+.input, .textarea {
+    width: 100%;
+    padding: 8px;
+    border: 1px solid #ccc;
+    border-radius: 4px;
+    margin-bottom: 8px;
+}
+textarea.textarea {
+    height: 30vh;
+}
+
+.button {
+    width: 100%;
+    padding: 10px;
+    border: none;
+    border-radius: 4px;
+    color: white;
+    cursor: pointer;
+}
+
+.button.connect {
+    background-color: #007bff;
+}
+
+.button.connect:hover {
+    background-color: #0056b3;
+}
+
+.button.subscribe {
+    background-color: #28a745;
+}
+
+.button.subscribe:hover {
+    background-color: #218838;
+}
+
+.button.send {
+    background-color: #dc3545;
+}
+
+.button.send:hover {
+    background-color: #c82333;
+}
+
+.messages {
+    margin-top: 16px;
+}
+
+.message {
+    background-color: #f8f9fa;
+    padding: 8px;
+    border-radius: 4px;
+    margin-bottom: 4px;
+    color:black;
+}

--- a/app/ws-testing/WebSocketClient.tsx
+++ b/app/ws-testing/WebSocketClient.tsx
@@ -1,0 +1,99 @@
+"use client";
+
+import React, { useRef, useState } from "react";
+import { Client } from "@stomp/stompjs";
+import SockJS from "sockjs-client";
+import "./WebSocketClient.css"; // Import the CSS file
+
+export default function WebSocketClient() {
+    const [messages, setMessages] = useState<string[]>([]);
+    const [url, setUrl] = useState<string>("http://localhost:8080/connections");
+    const [subscribeDestination, setSubscribeDestination] = useState<string>("/topic/game_states/1");
+    const [sendDestination, setSendDestination] = useState<string>("/ws/game_states/1");
+    const [sendBody, setSendBody] = useState<string>("{\"id\":1}");
+    const stompClientRef = useRef<Client | null>(null);
+
+    const connectWebSocket = () => {
+        const socket = new SockJS(url);
+        const stompClient = new Client({
+            webSocketFactory: () => socket,
+            reconnectDelay: 5000,
+            debug: (str) => console.log(str),
+        });
+
+        stompClient.onConnect = () => {
+            console.log("Connected to WebSocket");
+        };
+
+        stompClient.activate();
+        stompClientRef.current = stompClient;
+    };
+
+    const subscribeToDestination = () => {
+        stompClientRef.current?.subscribe(subscribeDestination, (message) => {
+            setMessages((prev) => [...prev, `📩 ${message.body}`]);
+        });
+    };
+
+    const sendMessage = () => {
+        stompClientRef.current?.publish({
+            destination: sendDestination,
+            body: sendBody,
+        });
+    };
+
+    return (
+        <div className="container">
+            <h2 className="title">WebSocket STOMP Client (Next.js)</h2>
+            <div className="input-group">
+                <input
+                    type="text"
+                    value={url}
+                    onChange={(e) => setUrl(e.target.value)}
+                    placeholder="WebSocket URL"
+                    className="input"
+                />
+                <button onClick={connectWebSocket} className="button connect">
+                    Connect
+                </button>
+            </div>
+            <div className="input-group">
+                <input
+                    type="text"
+                    value={subscribeDestination}
+                    onChange={(e) => setSubscribeDestination(e.target.value)}
+                    placeholder="Subscribe Destination"
+                    className="input"
+                />
+                <button onClick={subscribeToDestination} className="button subscribe">
+                    Subscribe
+                </button>
+            </div>
+            <div className="input-group">
+                <input
+                    type="text"
+                    value={sendDestination}
+                    onChange={(e) => setSendDestination(e.target.value)}
+                    placeholder="Send Destination"
+                    className="input"
+                />
+                <textarea
+                    value={sendBody}
+                    onChange={(e) => setSendBody(e.target.value)}
+                    placeholder="Message Body (JSON)"
+                    className="textarea"
+                />
+                <button onClick={sendMessage} className="button send">
+                    Send Message
+                </button>
+            </div>
+            <div className="messages">
+                {messages.map((msg, idx) => (
+                    <div key={idx} className="message">
+                        {msg}
+                    </div>
+                ))}
+            </div>
+        </div>
+    );
+}

--- a/app/ws-testing/page.tsx
+++ b/app/ws-testing/page.tsx
@@ -1,0 +1,10 @@
+import WebSocketClient from "@/ws-testing/WebSocketClient";
+
+
+export default function Home() {
+    return (
+        <main className="min-h-screen bg-gray-100 flex items-center justify-center">
+            <WebSocketClient />
+        </main>
+    );
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,17 +10,20 @@
       "dependencies": {
         "@ant-design/nextjs-registry": "^1.0.2",
         "@ant-design/v5-patch-for-react-19": "^1.0.3",
+        "@stomp/stompjs": "^7.1.0",
         "next": "^15.2.0",
         "node-localstorage": "^3.0.5",
         "process": "^0.11.10",
         "react": "^19.0.0",
-        "react-dom": "^19.0.0"
+        "react-dom": "^19.0.0",
+        "sockjs-client": "^1.6.1"
       },
       "devDependencies": {
         "@eslint/eslintrc": "^3.3.0",
         "@types/node": "^22.13.5",
         "@types/react": "^19.0.10",
         "@types/react-dom": "^19.0.4",
+        "@types/sockjs-client": "^1.5.4",
         "eslint": "^9.21.0",
         "eslint-config-next": "^15.2.0",
         "typescript": "^5"
@@ -1113,6 +1116,11 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@stomp/stompjs": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/@stomp/stompjs/-/stompjs-7.1.0.tgz",
+      "integrity": "sha512-73myzb9gKUIu6hq/NoN8yvR2hPnFfWcxDAZ3/wp4UQ1+JXaX7LR3CDJHx68BNYrFpuC0NgXry1krIb3q3SHUOg=="
+    },
     "node_modules/@swc/counter": {
       "version": "0.1.3",
       "resolved": "https://registry.npmjs.org/@swc/counter/-/counter-0.1.3.tgz",
@@ -1178,6 +1186,12 @@
       "peerDependencies": {
         "@types/react": "^19.0.0"
       }
+    },
+    "node_modules/@types/sockjs-client": {
+      "version": "1.5.4",
+      "resolved": "https://registry.npmjs.org/@types/sockjs-client/-/sockjs-client-1.5.4.tgz",
+      "integrity": "sha512-zk+uFZeWyvJ5ZFkLIwoGA/DfJ+pYzcZ8eH4H/EILCm2OBZyHH6Hkdna1/UWL/CFruh5wj6ES7g75SvUB0VsH5w==",
+      "dev": true
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
       "version": "8.25.0",
@@ -2806,6 +2820,14 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/eventsource": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/eventsource/-/eventsource-2.0.2.tgz",
+      "integrity": "sha512-IzUmBGPR3+oUG9dUeXynyNmf91/3zUSJg1lCktzKw47OXuhco54U3r9B7O4XX+Rb1Itm9OZ2b0RkTs10bICOxA==",
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
@@ -2865,6 +2887,17 @@
       "license": "ISC",
       "dependencies": {
         "reusify": "^1.0.4"
+      }
+    },
+    "node_modules/faye-websocket": {
+      "version": "0.11.4",
+      "resolved": "https://registry.npmjs.org/faye-websocket/-/faye-websocket-0.11.4.tgz",
+      "integrity": "sha512-CzbClwlXAuiRQAlUyfqPgvPoNKTckTPGfwZV4ZdAhVcP2lh9KUxJg2b5GkE7XbjKQ3YJnQ9z6D9ntLAlB+tP8g==",
+      "dependencies": {
+        "websocket-driver": ">=0.5.1"
+      },
+      "engines": {
+        "node": ">=0.8.0"
       }
     },
     "node_modules/file-entry-cache": {
@@ -3222,6 +3255,11 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/http-parser-js": {
+      "version": "0.5.9",
+      "resolved": "https://registry.npmjs.org/http-parser-js/-/http-parser-js-0.5.9.tgz",
+      "integrity": "sha512-n1XsPy3rXVxlqxVioEWdC+0+M+SQw0DpJynwtOPo1X+ZlvdzTLtDBIJJlDQTnwZIFJrZSzSGmIOUdP8tu+SgLw=="
+    },
     "node_modules/ignore": {
       "version": "5.3.2",
       "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz",
@@ -3257,6 +3295,11 @@
       "engines": {
         "node": ">=0.8.19"
       }
+    },
+    "node_modules/inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
     },
     "node_modules/internal-slot": {
       "version": "1.1.0",
@@ -3921,7 +3964,6 @@
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/nanoid": {
@@ -4342,6 +4384,11 @@
       "engines": {
         "node": ">=6"
       }
+    },
+    "node_modules/querystringify": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/querystringify/-/querystringify-2.2.0.tgz",
+      "integrity": "sha512-FIqgj2EUvTa7R50u0rGsyTftzjYmv/a3hO345bZNrqabNqjtgiDMgmo4mkUjd+nzU5oF3dClKqFIPUKybUyqoQ=="
     },
     "node_modules/queue-microtask": {
       "version": "1.2.3",
@@ -5090,6 +5137,11 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/requires-port": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz",
+      "integrity": "sha512-KigOCHcocU3XODJxsu8i/j8T9tzT4adHiecwORRQ0ZZFcp7ahwXuRU1m+yuO90C5ZUyGeGfocHDI14M3L3yDAQ=="
+    },
     "node_modules/resize-observer-polyfill": {
       "version": "1.5.1",
       "resolved": "https://registry.npmjs.org/resize-observer-polyfill/-/resize-observer-polyfill-1.5.1.tgz",
@@ -5192,6 +5244,25 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/safe-buffer": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ]
     },
     "node_modules/safe-push-apply": {
       "version": "1.0.0",
@@ -5465,6 +5536,32 @@
       "optional": true,
       "dependencies": {
         "is-arrayish": "^0.3.1"
+      }
+    },
+    "node_modules/sockjs-client": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/sockjs-client/-/sockjs-client-1.6.1.tgz",
+      "integrity": "sha512-2g0tjOR+fRs0amxENLi/q5TiJTqY+WXFOzb5UwXndlK6TO3U/mirZznpx6w34HVMoc3g7cY24yC/ZMIYnDlfkw==",
+      "dependencies": {
+        "debug": "^3.2.7",
+        "eventsource": "^2.0.2",
+        "faye-websocket": "^0.11.4",
+        "inherits": "^2.0.4",
+        "url-parse": "^1.5.10"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://tidelift.com/funding/github/npm/sockjs-client"
+      }
+    },
+    "node_modules/sockjs-client/node_modules/debug": {
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.7.tgz",
+      "integrity": "sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==",
+      "dependencies": {
+        "ms": "^2.1.1"
       }
     },
     "node_modules/source-map-js": {
@@ -5946,6 +6043,36 @@
       "license": "BSD-2-Clause",
       "dependencies": {
         "punycode": "^2.1.0"
+      }
+    },
+    "node_modules/url-parse": {
+      "version": "1.5.10",
+      "resolved": "https://registry.npmjs.org/url-parse/-/url-parse-1.5.10.tgz",
+      "integrity": "sha512-WypcfiRhfeUP9vvF0j6rw0J3hrWrw6iZv3+22h6iRMJ/8z1Tj6XfLP4DsUix5MhMPnXpiHDoKyoZ/bdCkwBCiQ==",
+      "dependencies": {
+        "querystringify": "^2.1.1",
+        "requires-port": "^1.0.0"
+      }
+    },
+    "node_modules/websocket-driver": {
+      "version": "0.7.4",
+      "resolved": "https://registry.npmjs.org/websocket-driver/-/websocket-driver-0.7.4.tgz",
+      "integrity": "sha512-b17KeDIQVjvb0ssuSDF2cYXSg2iztliJ4B9WdsuB6J952qCPKmnVq4DyW5motImXHDC1cBT/1UezrJVsKw5zjg==",
+      "dependencies": {
+        "http-parser-js": ">=0.5.1",
+        "safe-buffer": ">=5.1.0",
+        "websocket-extensions": ">=0.1.1"
+      },
+      "engines": {
+        "node": ">=0.8.0"
+      }
+    },
+    "node_modules/websocket-extensions": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/websocket-extensions/-/websocket-extensions-0.1.4.tgz",
+      "integrity": "sha512-OqedPIGOfsDlo31UNwYbCFMSaO9m9G/0faIHj5/dZFDMFqPTcx6UwqyOy3COEaEOg/9VsGIpdqn62W5KhoKSpg==",
+      "engines": {
+        "node": ">=0.8.0"
       }
     },
     "node_modules/which": {

--- a/package.json
+++ b/package.json
@@ -12,17 +12,20 @@
   "dependencies": {
     "@ant-design/nextjs-registry": "^1.0.2",
     "@ant-design/v5-patch-for-react-19": "^1.0.3",
+    "@stomp/stompjs": "^7.1.0",
     "next": "^15.2.0",
     "node-localstorage": "^3.0.5",
     "process": "^0.11.10",
     "react": "^19.0.0",
-    "react-dom": "^19.0.0"
+    "react-dom": "^19.0.0",
+    "sockjs-client": "^1.6.1"
   },
   "devDependencies": {
     "@eslint/eslintrc": "^3.3.0",
     "@types/node": "^22.13.5",
     "@types/react": "^19.0.10",
     "@types/react-dom": "^19.0.4",
+    "@types/sockjs-client": "^1.5.4",
     "eslint": "^9.21.0",
     "eslint-config-next": "^15.2.0",
     "typescript": "^5"


### PR DESCRIPTION
Fixes #45 : Adds client for testing websocket using STOMP protocol

- allows to establish connection to websocket
- allows to subscribe to topics or queues
- allows to send messages to websocket destinations